### PR TITLE
Fix events validation: return empty array instead of throwing on empty input

### DIFF
--- a/src/services/apiFetcher.ts
+++ b/src/services/apiFetcher.ts
@@ -18,7 +18,7 @@ class ApiFetcher extends AbstractFetcher {
       const mappings = parseMappings(mappingsResponse.mappings);
       const events = parseEvents(stateResponse.odds);
       updateState(events, mappings);
-      Logger.debug(`Updated state with ${Object.keys(events).length} events`);
+      Logger.debug(`Updated state with ${events.length} events/${Object.keys(mappings).length} mappings`);
     } catch (error) {
       Logger.error(`Error in API fetcher: ${error}`);
     }

--- a/src/services/parser.ts
+++ b/src/services/parser.ts
@@ -28,7 +28,7 @@ export const parseMappings = (rawMappings?: string | null): MappingDict => {
 
 export const parseEvents = (rawEvents?: string | null): SportEvent[] => {
   if (!rawEvents?.trim()) {
-    throw new Error("Cannot parse events: Invalid events input");
+    return [];
   }
 
   return rawEvents.split(delimiters.event.separator).map((rawEvent, index) => parseEvent(rawEvent, index));

--- a/test/services/parser.test.ts
+++ b/test/services/parser.test.ts
@@ -114,8 +114,8 @@ describe("Parser", () => {
         { scenario: "null", input: null },
         { scenario: "undefined", input: undefined },
         { scenario: "whitespace only", input: " " },
-      ])("should throw error when events input is $scenario", ({ input }) => {
-        expect(() => parseEvents(input)).toThrow("Cannot parse events: Invalid events input");
+      ])("should return empty array when events input is $scenario", ({ input }) => {
+        expect(parseEvents(input)).toEqual([]);
       });
     });
   });


### PR DESCRIPTION
**Description:**
This PR fixes an issue in event validation where an empty string input was causing an exception. Instead of throwing an error, the function now returns an empty array when the input is an empty.

**Impact of the Bug:**
Previously, the validation logic incorrectly threw an exception when `/state` API returned no odds. As a result:
- the system failed to detect the end of the last event.
-  it incorrectly reported the last match as still being LIVE instead of recognizing its completion.
- this led to inaccurate data being returned to users.

**Changes:**
- modified the validation logic to return an empty array instead of throwing an error when the input is an empty string.
- updated the corresponding test case to reflect the expected behavior.
- ensured that all tests pass and edge cases are handled properly.
